### PR TITLE
Authenticate with auth token & storage URL

### DIFF
--- a/auth/destination.go
+++ b/auth/destination.go
@@ -133,3 +133,16 @@ func Authenticate(username, apiKey, authURL, domain, tenant string) (Destination
 	}
 	return &SwiftDestination{SwiftConnection: &connection}, nil
 }
+
+func AuthenticateWithToken(authToken, storageUrl string) (Destination, error) {
+	connection := swift.Connection{
+		StorageUrl: storageUrl,
+		AuthToken:  authToken,
+	}
+
+	if !connection.Authenticated() {
+		return &SwiftDestination{SwiftConnection: &connection}, fmt.Errorf("Connection not authenticated")
+	}
+
+	return &SwiftDestination{SwiftConnection: &connection}, nil
+}

--- a/auth/destination.go
+++ b/auth/destination.go
@@ -134,6 +134,9 @@ func Authenticate(username, apiKey, authURL, domain, tenant string) (Destination
 	return &SwiftDestination{SwiftConnection: &connection}, nil
 }
 
+// AuthenticateWithToken logs in to OpenStack object storage using the authentication token and
+// storage url and returns a connection to the object store. It also checks that the connection is
+// valid.
 func AuthenticateWithToken(authToken, storageUrl string) (Destination, error) {
 	connection := swift.Connection{
 		StorageUrl: storageUrl,


### PR DESCRIPTION
Added the ability to create a connection object with just the auth token and storage URL as opposed to entire service credential set.